### PR TITLE
add vars for RedHat

### DIFF
--- a/vars/RedHat.yaml
+++ b/vars/RedHat.yaml
@@ -1,0 +1,4 @@
+---
+
+auditd_packages: audit
+auditd_dependencies:


### PR DESCRIPTION
This creates a var file for the `ansible_os_family` that is referenced in `tasks/main.yaml`
Without this vars file the role does not work for CentOS or Rocky Linux which both have RedHat as their `ansible_os_family`