### PR TITLE
add config option for global filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ auditd_custom_rules:
       - arch=b64
     executable: /bin/id
     comment: execution_bin_id
+  # define general filter rule
+  - type: global_filter
+    action: always,exit
+    filters:
+      - dir=/opt/application
+      - perm=wa
 ```
 
 All the configurations for the audit daemon are configurable as variables. See `defaults/main.yaml` for more details.

--- a/templates/custom.rules.j2
+++ b/templates/custom.rules.j2
@@ -21,5 +21,8 @@
 {% if rule.type == 'executable' %}
 -a {{ rule.action }} -F exe={{ rule.executable }}{% if rule.filters is defined %}{% for filter in rule.filters %} -F {{ filter }}{% endfor %}{% endif %} -S execve -k {{ rule.comment }}
 {% endif %}
+{% if rule.type == 'global_filter' %}
+-a {{ rule.action }}{% if rule.filters is defined %}{% for filter in rule.filters %} -F {{ filter }}{% endfor %}{% endif %}
+{% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
This allows the creation of global filters without the need for a comment.
Rules in the style of this https://access.redhat.com/solutions/2482221 article.