### PR TITLE
Fix/jinja whitespace

### DIFF
--- a/templates/custom.rules.j2
+++ b/templates/custom.rules.j2
@@ -13,16 +13,16 @@
 {% if auditd_custom_rules is defined %}
 {% for rule in auditd_custom_rules %}
 {% if rule.type == 'filesystem' %}
--w {{ rule.file }} -p {{ rule.permissions }} -k {{ rule.comment }}
+-w {{ rule.file }} -p {{ rule.permissions }} {% if rule.comment is defined %} -k {{ rule.comment }}{% endif %}{{''}}
 {% endif %}
 {% if rule.type == 'syscall' %}
--a {{ rule.action }}{% if rule.filters is defined %}{% for filter in rule.filters %} -F {{ filter }}{% endfor %}{% endif %}{% if rule.syscalls is defined %}{% for syscall in rule.syscalls %} -S {{ syscall }}{% endfor %}{% endif %} -k {{ rule.comment }}
+-a {{ rule.action }}{% if rule.filters is defined %}{% for filter in rule.filters %} -F {{ filter }}{% endfor %}{% endif %}{% if rule.syscalls is defined %}{% for syscall in rule.syscalls %} -S {{ syscall }}{% endfor %}{% endif %} {% if rule.comment is defined %} -k {{ rule.comment }}{% endif %}{{''}}
 {% endif %}
 {% if rule.type == 'executable' %}
--a {{ rule.action }} -F exe={{ rule.executable }}{% if rule.filters is defined %}{% for filter in rule.filters %} -F {{ filter }}{% endfor %}{% endif %} -S execve -k {{ rule.comment }}
+-a {{ rule.action }} -F exe={{ rule.executable }}{% if rule.filters is defined %}{% for filter in rule.filters %} -F {{ filter }}{% endfor %}{% endif %} -S execve {% if rule.comment is defined %} -k {{ rule.comment }}{% endif %}{{''}}
 {% endif %}
 {% if rule.type == 'global_filter' %}
--a {{ rule.action }}{% if rule.filters is defined %}{% for filter in rule.filters %} -F {{ filter }}{% endfor %}{% endif %}{{''}}
+-a {{ rule.action }}{% if rule.filters is defined %}{% for filter in rule.filters %} -F {{ filter }}{% endfor %}{% endif %}{% if rule.comment is defined %} -k {{ rule.comment }}{% endif %}{{''}}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/templates/custom.rules.j2
+++ b/templates/custom.rules.j2
@@ -22,7 +22,7 @@
 -a {{ rule.action }} -F exe={{ rule.executable }}{% if rule.filters is defined %}{% for filter in rule.filters %} -F {{ filter }}{% endfor %}{% endif %} -S execve -k {{ rule.comment }}
 {% endif %}
 {% if rule.type == 'global_filter' %}
--a {{ rule.action }}{% if rule.filters is defined %}{% for filter in rule.filters %} -F {{ filter }}{% endfor %}{% endif %}
+-a {{ rule.action }}{% if rule.filters is defined %}{% for filter in rule.filters %} -F {{ filter }}{% endfor %}{% endif %}{{''}}
 {% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
According to the documentation `-k` is completely optional. This changes reflects this in ansible.
The {{''}} at the end of the line is a semi-dirty hack to force a newline despite having Trim_blocks: True set in Ansible.